### PR TITLE
Use application name for icons when not provided by audio engine

### DIFF
--- a/libs/widgets.js
+++ b/libs/widgets.js
@@ -53,6 +53,7 @@ var ApplicationsMixer = class ApplicationsMixer extends PopupMenu.PopupMenuSecti
         this._sliders = {};
         this.filter_mode = filter_mode;
         this.filters = filters.map(f => new RegExp(f));
+        this._icon_theme = St.IconTheme.new();
 
         this._mixer_control = Volume.getMixerControl();
         this._sa_event_id = this._mixer_control.connect("stream-added", this._stream_added.bind(this));
@@ -82,7 +83,8 @@ var ApplicationsMixer = class ApplicationsMixer extends PopupMenu.PopupMenuSecti
 
         const slider = new ApplicationVolumeSlider(
             this._mixer_control,
-            stream
+            stream,
+            this._icon_theme
         );
         this._sliders[id] = slider;
         this.actor.add(slider);
@@ -112,13 +114,13 @@ var ApplicationsMixer = class ApplicationsMixer extends PopupMenu.PopupMenuSecti
 
 var ApplicationVolumeSlider = GObject.registerClass(
     class ApplicationVolumeSlider extends StreamSlider {
-        constructor(control, stream) {
+        constructor(control, stream, icon_theme) {
             super(control);
 
             // This line need to be BEFORE this.stream assignement to prevent an error from appearing in the logs.
             // Note that icons can't be found anyway
             this._icons = [stream.get_icon_name()];
-            if (stream.get_name() != null && stream.get_icon_name()=="applications-multimedia") {
+            if (stream.get_name() != null && icon_theme.has_icon(stream.get_name().toLowerCase())) {
                 this._icons = [stream.get_name().toLowerCase()]
             }
             this.stream = stream;

--- a/libs/widgets.js
+++ b/libs/widgets.js
@@ -118,6 +118,9 @@ var ApplicationVolumeSlider = GObject.registerClass(
             // This line need to be BEFORE this.stream assignement to prevent an error from appearing in the logs.
             // Note that icons can't be found anyway
             this._icons = [stream.get_icon_name()];
+            if (stream.get_name() != null && stream.get_icon_name()=="applications-multimedia") {
+                this._icons = [stream.get_name().toLowerCase()]
+            }
             this.stream = stream;
 
             const vbox = new St.BoxLayout({ vertical: true });


### PR DESCRIPTION
This will set the icon string to lower-case application name. It helps for applications which do not provide the icon to audio engine (for example Firefox).
`/usr/share/icons/...` contains lots of application icons in lower case so this should work for many applications.

If the icon is set properly, it will use that instead.

Example of fixed Firefox icon, while Spotify icon comes from pipewire:

![image](https://github.com/Rayzeq/quick-settings-audio-panel/assets/1036439/60ff1dad-5d61-4b2a-b033-6e4e0c525cd0)
