### PR TITLE
Bind to stream description changes #14

### DIFF
--- a/libs/widgets.js
+++ b/libs/widgets.js
@@ -129,14 +129,23 @@ var ApplicationVolumeSlider = GObject.registerClass(
 
             const label = new St.Label({ natural_width: 0 });
             label.style_class = "QSAP-application-volume-slider-label";
-            if (stream.get_name() == null) {
-                label.text = `${stream.get_description()}`;
-            } else {
-                label.text = `${stream.get_name()} - ${stream.get_description()}`;
-            }
+
+            stream.bind_property_full('description', label, 'text',
+                GObject.BindingFlags.SYNC_CREATE, (binding, value) => {
+                    return [true, this._get_label_text(stream)];
+                },
+                null, );
 
             vbox.add(label);
             vbox.add(slider);
+        }
+
+        _get_label_text(stream) {
+            if (stream.get_name() == null) {
+                return `${stream.get_description()}`;
+            } else {
+                return `${stream.get_name()} - ${stream.get_description()}`;
+            }
         }
     }
 )


### PR DESCRIPTION
After checking that the stream description gets updated, I used the [GObject property binding](https://gjs.guide/guides/gobject/basics.html#property-bindings) to keep the description updated.
Seems to work great when testing with Youtube on Firefox.

Fixes #14 