### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,package-lock.json,*.css,.codespellrc,po
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/libs/widgets.ts
+++ b/libs/widgets.ts
@@ -697,7 +697,7 @@ const ApplicationVolumeSlider = GObject.registerClass(class ApplicationVolumeSli
                 'active-output-update', (_control: Gvc.MixerControl, _id: number) => this._checkUsedSink(),
                 this
             );
-            // unfortunatly we don't have any signal to know that the active device changed
+            // unfortunately we don't have any signal to know that the active device changed
             //stream.connect('', () => this._setActiveDevice());
         
             for (const sink of control.get_sinks()) {
@@ -709,10 +709,10 @@ const ApplicationVolumeSlider = GObject.registerClass(class ApplicationVolumeSli
             }
         }
 
-        // This line need to be BEFORE this.stream assignement to prevent an error from appearing in the logs.
+        // This line need to be BEFORE this.stream assignment to prevent an error from appearing in the logs.
         this._icons = [stream.name ? stream.name.toLowerCase() : stream.icon_name];
         this.stream = stream;
-        // And this one need to be after this.stream assignement.
+        // And this one need to be after this.stream assignment.
         this._icon.fallback_icon_name = stream.icon_name;
 
         if (this._pactl_path) {


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

just a few typos in comments -- feel free to ignore ;)