### PR TITLE
fix: close leaked file descriptors in spawn() utility

### DIFF
--- a/libs/utils.ts
+++ b/libs/utils.ts
@@ -16,19 +16,23 @@ export function get_pactl_path(settings: Gio.Settings): [string | null, boolean]
 
 export function spawn(argv: string[]): Promise<string> {
 	return new Promise((resolve, _reject) => {
-		const [, , , stdout,] = GLib.spawn_async_with_pipes(null, argv, null, GLib.SpawnFlags.SEARCH_PATH, null);
-		const stdout_reader = new Gio.DataInputStream({
-			base_stream: new GioUnix.InputStream({ fd: stdout })
-		});
+		const [, , stdin_fd, stdout_fd, stderr_fd] = GLib.spawn_async_with_pipes(null, argv, null, GLib.SpawnFlags.SEARCH_PATH, null);
+
+		GLib.close(stdin_fd);
+		GLib.close(stderr_fd);
+
+		const stdout_stream = new GioUnix.InputStream({ fd: stdout_fd, close_fd: true });
+		const stdout_reader = new Gio.DataInputStream({ base_stream: stdout_stream });
 		const result_string: string[] = [];
 
 		const readline_callback = (_: Gio.DataInputStream | null, result: Gio.AsyncResult) => {
-			const [stdout, length] = stdout_reader.read_upto_finish(result);
+			const [data, length] = stdout_reader.read_upto_finish(result);
 
 			if (length > 0) {
-				result_string.push(stdout);
+				result_string.push(data);
 				stdout_reader.read_upto_async("", 0, 0, null, readline_callback);
 			} else {
+				stdout_reader.close(null);
 				resolve(result_string.join("\n"));
 			}
 		};


### PR DESCRIPTION
## Summary

- Close stdin and stderr pipe FDs returned by `GLib.spawn_async_with_pipes()` that were silently discarded in the `spawn()` helper
- Create stdout `UnixInputStream` with `close_fd: true` for automatic cleanup
- Explicitly close `DataInputStream` when reading is complete instead of relying on GC

Each call to `spawn()` leaked 2-3 file descriptors. Over long uptimes with frequent audio stream events (especially during monitor connect/disconnect which triggers sink reconfiguration), this exhausts gnome-shell's per-process FD limit, producing `Too many open files` errors and freezing click input while the cursor still moves.

## Test plan

- [ ] Verify per-app volume sliders still detect correct sink assignment
- [ ] Monitor gnome-shell FD count over time: `ls /proc/$(pgrep gnome-shell)/fd | wc -l`
- [ ] Confirm no "Too many open files" errors in `journalctl -f /usr/bin/gnome-shell` after extended use

Fixes #122

> Companion to #123 which fixes the same bug on the g46 branch (inline JS version).